### PR TITLE
chore(workflow): secrets cannot be used in conditionals

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -22,7 +22,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Checkout lousy-agents docs
-        if: ${{ secrets.COPILOT_DOCS_GITHUB_TOKEN != '' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: zpratt/lousy-agents


### PR DESCRIPTION
Removed conditional check for COPILOT_DOCS_GITHUB_TOKEN.