### PR TITLE
Remove non-functional Settings icon from site header

### DIFF
--- a/src/components/layout/SiteHeader.tsx
+++ b/src/components/layout/SiteHeader.tsx
@@ -167,18 +167,6 @@ function DesktopHeader({ currentPathname }: DesktopHeaderProps) {
                 <button
                     type="button"
                     style={iconButtonStyle}
-                    aria-label="Settings"
-                >
-                    <span
-                        className="material-symbols-outlined"
-                        aria-hidden="true"
-                    >
-                        settings
-                    </span>
-                </button>
-                <button
-                    type="button"
-                    style={iconButtonStyle}
                     aria-label="Open terminal"
                 >
                     <span
@@ -234,18 +222,6 @@ export function MobileHeader({ onMenuToggle, isMenuOpen }: MobileHeaderProps) {
                         aria-hidden="true"
                     >
                         search
-                    </span>
-                </button>
-                <button
-                    type="button"
-                    style={iconButtonStyle}
-                    aria-label="Settings"
-                >
-                    <span
-                        className="material-symbols-outlined"
-                        aria-hidden="true"
-                    >
-                        settings
                     </span>
                 </button>
             </Flex>

--- a/tests/components/layout/SiteHeader.test.tsx
+++ b/tests/components/layout/SiteHeader.test.tsx
@@ -104,6 +104,14 @@ describe("SiteHeader", () => {
             ).not.toBeInTheDocument();
         });
 
+        it("should not render a non-functional settings button", () => {
+            render(<SiteHeader isMobile={false} />);
+
+            expect(
+                screen.queryByRole("button", { name: /settings/i }),
+            ).not.toBeInTheDocument();
+        });
+
         describe("keyboard shortcut hint", () => {
             let userAgentSpy: MockInstance;
 
@@ -280,6 +288,14 @@ describe("SiteHeader", () => {
 
             expect(screen.queryByText("⌘K")).not.toBeInTheDocument();
             expect(screen.queryByText("Ctrl+K")).not.toBeInTheDocument();
+        });
+
+        it("should not render a non-functional settings button", () => {
+            render(<SiteHeader isMobile={true} />);
+
+            expect(
+                screen.queryByRole("button", { name: /settings/i }),
+            ).not.toBeInTheDocument();
         });
 
         it("should render a mobile menu button when a toggle handler is provided", () => {


### PR DESCRIPTION
## Summary
- Removed the gear/Settings icon button from both the desktop and mobile `SiteHeader` — it had no `onClick` handler or any other behavior, and `DESIGN.md` documents no settings panel or configurable options for this single fixed-theme static site
- Added tests asserting the Settings button is no longer rendered in either header variant

## Context
Fixes zpratt/lousy-agents#712, which reported that the gear icon in the upper-right of the docs page did nothing when clicked. Since there's no defined product purpose for a settings panel, the dead button was removed rather than wiring up a placeholder feature.

## Test plan
- [x] `npx biome check` — passes
- [x] `npm test` — all 267 tests pass, including two new tests confirming the Settings button is absent (desktop and mobile)
- [x] `npm run build` — production build succeeds
- [x] Visual check via a local preview + screenshot confirms the header renders cleanly with no leftover spacing where the icon was removed (desktop: Search + terminal icons remain; mobile: Search icon remains)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PiAi9buxpW4ZRmktY2VSNb)_